### PR TITLE
stack test instead of cabal test

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test all
+      run: stack test


### PR DESCRIPTION
cabal test が GitHub Actions で通らないのでローカルで確認取れている stack test を使うようにします。