### PR TITLE
fix 'Playing Together'

### DIFF
--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -6,6 +6,8 @@ import Data.Array (Array)
 import Data.Array.IArray ((!), listArray)
 import Data.Array.Unboxed (UArray)
 import Data.Function (on)
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
 import Data.List (sortBy, groupBy)
 import Data.IORef (IORef, newIORef)
 import Text.Printf (printf)
@@ -28,10 +30,10 @@ mkProblemExtra Problem{..} =
   ProblemExtra
   { num_musicians = length musicians
   , num_attendees = length attendees
-  , num_instruments = maximum (0 : musicians) + 1
+  , num_instruments = num_instruments
   , attendees_int_compat = all compatA attendees
   , million_times_atnds_tastes = listArray (0, length attendees - 1) $ map million_times_tastes attendees
-  , same_inst_musicians = listArray (0, length musicians - 1) group_by_inst
+  , same_inst_musicians = same_inst_musicians
   }
   where
     compatA Attendee{..} = IntCompat.double x && IntCompat.double y
@@ -40,7 +42,11 @@ mkProblemExtra Problem{..} =
     million_times_tastes :: Attendee -> UArray Int Double
     million_times_tastes a = listArray (0, length ts - 1) $ map (1e6 *) ts  where ts = tastes a
 
-    group_by_inst = map (map fst) $ groupBy ((==)`on`snd) $ sortBy (compare`on`snd) $ zip [0..] musicians
+    num_instruments = maximum (0 : musicians) + 1
+
+    same_inst_musicians = listArray (0, num_instruments - 1) [IntMap.findWithDefault [] inst m | inst <- [0 .. num_instruments - 1]]
+      where
+        m = IntMap.fromListWith (++) $ zip musicians $ map (\k -> [k]) [0..]
 
 
 pprProblemExtraShort :: ProblemExtra -> String

--- a/src/Happiness.hs
+++ b/src/Happiness.hs
@@ -95,14 +95,16 @@ naive extra prob ans = pure score
     insts = musicians prob
     plrs = pillars prob
 
-    impact (i, a_i) (_k, inst_k, p_k) = ceiling $ (closeness * num) / den
+    impact (i, a_i) (k, inst_k, p_k)
+      | isFullDivisionProblem prob = ceiling $ closeness * fromIntegral (ceiling (num / den) :: Happiness)
+      | otherwise = ceiling (num / den)
       where
-        num = (million_times_atnds_tastes.problem_extra $ extra)! i ! inst_k
+        num = (million_times_atnds_tastes.problem_extra $ extra) ! i ! inst_k
         den = squareDistance p_k a_i
         closeness = 1 + 
-          sum[ 1/(squareDistance p_k (ms_ar!j))
-             | inst<-insts, inst/=inst_k
-             , j <-(same_inst_musicians.problem_extra $ extra)! inst
+          sum[ 1 / squareDistance p_k (ms_ar!j)
+             | j <- (same_inst_musicians.problem_extra $ extra) ! inst_k
+             , k /= j
              ]
 
 withQueue :: Extra -> Problem -> Answer -> IO Happiness


### PR DESCRIPTION
Playing Together 周りがバグっているような。

* `same_inst_musicians` の定義が変。 
  * 長さはミュージシャン数ではなく楽器数のはず
  * ミュージシャンのいない楽器があるバグる
* 有効になるのは full round の問題だけのはず
* 問題文的には ceiling を二重にかける必要があるはず