### PR TITLE
GitHub Actions: build only with stack

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -29,18 +29,6 @@ jobs:
     - name: Setup stack
       run: stack config set system-ghc --global true
 
-    - name: Cache ~/.cabal
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-cabal
-      with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
     - name: Cache ~/.stack
       uses: actions/cache@v3
       env:
@@ -50,10 +38,10 @@ jobs:
         key: ${{ runner.os }}-stack
 
     - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+      run: stack build --test --no-run-tests --bench --no-run-benchmarks --only-dependencies
+
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: stack build --test --no-run-tests --bench --no-run-benchmarks
+
     - name: Run tests
       run: stack test


### PR DESCRIPTION
Previously it was built with both stack and cabal and took twice as long.

もともと Cabal と Stack の両方でビルドしてて倍の時間がかかっていて、かつ Stack に関してはビルド結果をキャッシュしてなかったので、CIにむっちゃ時間がかかっていた。

#13 で Stack でのビルドについてもキャッシュするようにした。

このPRでは Cabal でのビルドをやめて Stack だけにしてる。